### PR TITLE
Bad Actor Identification

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -1,0 +1,8 @@
+# You can run this script to restart the tracker service with the latest changes and config.
+
+./trakx stop
+# force the new yaml to be used
+rm ~/.config/trakx/trakx.yaml
+# build with latest changes
+go build
+./trakx start

--- a/tracker/config/config.go
+++ b/tracker/config/config.go
@@ -62,6 +62,9 @@ type Configuration struct {
 		Trim   time.Duration
 		Expiry time.Duration
 	}
+	Behavior struct {
+		MinLeechers uint16
+	}
 	Path struct {
 		Log string
 		Pid string
@@ -146,6 +149,11 @@ func (config *Configuration) Parse() error {
 	// resolve env vars for database backup path
 	if strings.HasPrefix(config.DB.Backup.Path, "ENV:") {
 		config.DB.Backup.Path = os.Getenv(strings.TrimPrefix(config.DB.Backup.Path, "ENV:"))
+	}
+
+	// behavior
+	if config.Behavior.MinLeechers < 2 {
+		config.Behavior.MinLeechers = 2 // should have another leecher other than self to upload at minimum
 	}
 
 	// resolve paths

--- a/tracker/config/embedded/trakx.yaml
+++ b/tracker/config/embedded/trakx.yaml
@@ -110,6 +110,11 @@ db:
   # should: expiry >= announce_base + announce_fuzz
   expiry: 40m
 
+# bad actor identification
+behavior:
+  # minimum number of leechers in the swarm that enforces uploading between announcements
+  minleechers: 5
+
 # file paths
 path:
   log: "~/.cache/trakx/trakx.log"

--- a/tracker/http/announce.go
+++ b/tracker/http/announce.go
@@ -13,14 +13,16 @@ import (
 )
 
 type announceParams struct {
-	compact  bool
-	nopeerid bool
-	noneleft bool
-	event    string
-	port     string
-	hash     string
-	peerid   string
-	numwant  string
+	compact    bool
+	nopeerid   bool
+	noneleft   bool
+	event      string
+	port       string
+	hash       string
+	peerid     string
+	numwant    string
+	uploaded   int64
+	downloaded int64
 }
 
 func (t *HTTPTracker) announce(conn net.Conn, vals *announceParams, ip netip.Addr) {
@@ -82,7 +84,11 @@ func (t *HTTPTracker) announce(conn net.Conn, vals *announceParams, ip netip.Add
 		peerComplete = true
 	}
 
-	t.peerdb.Save(ip, uint16(portInt), peerComplete, hash, peerid)
+	// Also update upload and download information
+	uploaded := vals.uploaded
+	downloaded := vals.downloaded
+
+	t.peerdb.Save(ip, uint16(portInt), peerComplete, hash, peerid, uploaded, downloaded)
 	complete, incomplete := t.peerdb.HashStats(hash)
 
 	interval := int64(config.Config.Announce.Base.Seconds())

--- a/tracker/http/download_calculate.go
+++ b/tracker/http/download_calculate.go
@@ -7,12 +7,14 @@ import (
 	"github.com/crimist/trakx/pools"
 )
 
+// Note: this file is currently not in use.
+// If needed to incorporate the logic for bad actor identification, changes can be made in storage/map/peer.go.
+
 type downloadUploadParams struct {
 	downloadbytes int
-	uploadbytes int
-	infohash string
+	uploadbytes   int
+	infohash      string
 }
-
 
 func (t *HTTPTracker) calculate_speed(conn net.Conn, vals downloadUploadParams) {
 	if reflect.ValueOf(vals).IsZero() {
@@ -23,7 +25,7 @@ func (t *HTTPTracker) calculate_speed(conn net.Conn, vals downloadUploadParams) 
 	if vals.infohash == "" {
 		t.clientError(conn, "no infohash")
 		return
-	} 
+	}
 
 	if vals.downloadbytes == 0 {
 		t.clientTorrentHashToDownload[vals.infohash] = 0
@@ -32,12 +34,12 @@ func (t *HTTPTracker) calculate_speed(conn net.Conn, vals downloadUploadParams) 
 	}
 
 	if lastDownloadAmount, ok := t.clientTorrentHashToDownload[vals.infohash]; ok {
-		t.downloadSpeed = (vals.downloadbytes-lastDownloadAmount)
+		t.downloadSpeed = (vals.downloadbytes - lastDownloadAmount)
 		t.clientTorrentHashToDownload[vals.infohash] = vals.downloadbytes
 	} else {
 		t.clientTorrentHashToDownload[vals.infohash] = vals.downloadbytes
 		t.downloadSpeed = vals.downloadbytes
-		// download per second 
+		// download per second
 	}
 	// fmt.Println("downloadspeed")
 	dictionary := pools.Dictionaries.Get()

--- a/tracker/storage/database.go
+++ b/tracker/storage/database.go
@@ -45,7 +45,7 @@ type Database interface {
 	Trim()
 	SyncExpvars() error
 
-	Save(netip.Addr, uint16, bool, Hash, PeerID)
+	Save(netip.Addr, uint16, bool, Hash, PeerID, int64, int64) bool
 	Drop(Hash, PeerID)
 
 	HashStats(Hash) (uint16, uint16)

--- a/tracker/storage/map/encode_binary_test.go
+++ b/tracker/storage/map/encode_binary_test.go
@@ -23,7 +23,7 @@ func TestEncodeDecodeBinary(t *testing.T) {
 		Port:     0x4f50,
 		LastSeen: time.Now().Unix(),
 	}
-	db.Save(peer.IP, peer.Port, peer.Complete, hash, peerid)
+	db.Save(peer.IP, peer.Port, peer.Complete, hash, peerid, peer.Uploaded, peer.Downloaded)
 
 	oldhahmap := db.hashmap
 	data, err := db.encodeBinary()

--- a/tracker/storage/map/encode_gob_test.go
+++ b/tracker/storage/map/encode_gob_test.go
@@ -16,12 +16,14 @@ func TestEncodeDecodeGob(t *testing.T) {
 	hash := storage.Hash{0x48, 0x61, 0x73, 0x68, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
 	peerid := storage.PeerID{0x49, 0x44, 0x49, 0x44, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
 	peer := storage.Peer{
-		Complete: true,
-		IP:       netip.MustParseAddr("127.0.0.1"),
-		Port:     0x4f50,
-		LastSeen: time.Now().Unix(),
+		Complete:   true,
+		IP:         netip.MustParseAddr("127.0.0.1"),
+		Port:       0x4f50,
+		LastSeen:   time.Now().Unix(),
+		Uploaded:   1234,
+		Downloaded: 4321,
 	}
-	db.Save(peer.IP, peer.Port, peer.Complete, hash, peerid)
+	db.Save(peer.IP, peer.Port, peer.Complete, hash, peerid, peer.Uploaded, peer.Downloaded)
 
 	oldhahmap := db.hashmap
 	data, err := db.encodeGob()

--- a/tracker/storage/map/hash_test.go
+++ b/tracker/storage/map/hash_test.go
@@ -28,7 +28,7 @@ func dbWithHashesAndPeers(hashes, peers int) *Memory {
 
 		for i := 0; i < peers; i++ {
 			rand.Read(peerid[:])
-			db.Save(peer.IP, peer.Port, peer.Complete, h, peerid)
+			db.Save(peer.IP, peer.Port, peer.Complete, h, peerid, peer.Uploaded, peer.Downloaded)
 		}
 	}
 
@@ -53,7 +53,7 @@ func dbWithHashes(count int) *Memory {
 		rand.Read(hash)
 		copy(h[:], hash)
 
-		db.Save(peer.IP, peer.Port, peer.Complete, h, peerid)
+		db.Save(peer.IP, peer.Port, peer.Complete, h, peerid, peer.Uploaded, peer.Downloaded)
 	}
 
 	return &db
@@ -78,7 +78,7 @@ func dbWithPeers(count int) (*Memory, storage.Hash) {
 		rand.Read(peerid)
 		copy(p[:], peerid)
 
-		db.Save(peer.IP, peer.Port, peer.Complete, hash, p)
+		db.Save(peer.IP, peer.Port, peer.Complete, hash, p, peer.Uploaded, peer.Downloaded)
 	}
 
 	return &db, hash

--- a/tracker/storage/types.go
+++ b/tracker/storage/types.go
@@ -10,9 +10,12 @@ type (
 
 	// Peer contains requied peer information for database.
 	Peer struct {
-		Complete bool
-		IP       netip.Addr
-		Port     uint16
-		LastSeen int64
+		Complete         bool
+		IP               netip.Addr
+		Port             uint16
+		LastSeen         int64
+		Uploaded         int64
+		Downloaded       int64
+		LeechersLastTime uint16
 	}
 )

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -93,9 +93,6 @@ func Run() {
 		mux.HandleFunc("/announce", func(w gohttp.ResponseWriter, r *gohttp.Request) {
 			w.Write(announceResponse)
 		})
-		mux.HandleFunc("/download", func(w gohttp.ResponseWriter, r *gohttp.Request) {})
-
-
 
 		for filepath, data := range cache {
 			dataBytes := []byte(data)

--- a/tracker/udp/announce.go
+++ b/tracker/udp/announce.go
@@ -53,7 +53,7 @@ func (u *UDPTracker) announce(announce *protocol.Announce, remote *net.UDPAddr, 
 		peerComplete = true
 	}
 
-	u.peerdb.Save(addrPort.Addr(), announce.Port, peerComplete, announce.InfoHash, announce.PeerID)
+	u.peerdb.Save(addrPort.Addr(), announce.Port, peerComplete, announce.InfoHash, announce.PeerID, announce.Uploaded, announce.Downloaded)
 
 	complete, incomplete := u.peerdb.HashStats(announce.InfoHash)
 	peers4, peers6 := u.peerdb.PeerListBytes(announce.InfoHash, uint(announce.NumWant))


### PR DESCRIPTION
Changes:
 - Extend the tracker storage DB model to keep track of download, upload amount of each peer, as well as the number of leechers since the last announce
 - A first-attempt at the identification logic of a bad actor: if a leecher uploads nothing yet downloads something since last time it announces, despite the fact that there were multiple leechers as potential receivers of its pieces, it is considered a bad actor and is flagged (with the promotion/demotion unspecified as of now)
 - Clean up the previous `/download` changes
 - **Add a restart.sh script which you can use to restart the tracker with the latest implementation and configuration in the yaml file**
 - There are a bunch of mininum changes to the existing tests written by the original author within this repo to at least get them compiled, however their correctness is not guaranteed

Testing:
 - Through changing the minimum number of leechers to be considered for the identification logic (called `MinLeechers` in the configuration) and logging, correctly produce when a peer should be a bad actor. (For ease of testing, you should set `Base` and `Fuzz` in config for the announce interval given by the tracker) as 1s and 0s
 - Validation PR: https://github.com/Maxwell-Yang-2001/reliableBT-validation/pull/2