### PR TITLE
Fix announce interval to be 1s for testing

### DIFF
--- a/tracker/config/embedded/trakx.yaml
+++ b/tracker/config/embedded/trakx.yaml
@@ -20,9 +20,9 @@ debug:
 
 # announce interval = base + [0, fuzz]
 announce:
-  base: 30m
+  base: 1s
   # fuzz >= 0
-  fuzz: 5m
+  fuzz: 0s
 
 # http tracker vars
 http:


### PR DESCRIPTION
Previous announce interval is set to be 30m +/- 5m, which we change to 1s during local testing. Committing this as the final version of the configuration for our purpose.